### PR TITLE
Adds fixed weights and cred flows to edges

### DIFF
--- a/graph_converter.py
+++ b/graph_converter.py
@@ -62,6 +62,10 @@ def convert_graph(input_graph_path, output_path, output_format):
     for cred_edge in graph[1]['orderedEdges']:
         igraph_edge_atts = {'address': '-'.join(cred_edge['address']),
                             'timestamp': cred_edge['timestamp'],
+                            'backwardsWeight': cred_edge['rawWeight']['backwards'], 
+                            'forwardsWeight': cred_edge['rawWeight']['forwards'],
+                            'backwardFlow': cred_edge['totalCred']['backwardFlow'],
+                            'forwardFlow': cred_edge['totalCred']['forwardFlow'],  
                             #'credOverTime': cred_edge['credOverTime'] # To play with cred
                             }
         try:


### PR DESCRIPTION
In order to analyze cred flows across nodes, it will be helpful to know the fixed weights (backwards & forwards) on each edge, as well as the amount of cred that ultimately flowed across those edges. This PR adds this information as edge attributes. 